### PR TITLE
Allow multiple decompressors

### DIFF
--- a/src/ServiceBus.CompressionPlugin.Tests/ApprovalFiles/ApiApprovals.CompressionPlugin.approved.txt
+++ b/src/ServiceBus.CompressionPlugin.Tests/ApprovalFiles/ApiApprovals.CompressionPlugin.approved.txt
@@ -3,7 +3,9 @@ namespace Microsoft.Azure.ServiceBus
 {
     public class CompressionConfiguration
     {
-        public CompressionConfiguration(string compressionMethodName, System.Func<byte[], byte[]> compressor, System.Func<byte[], byte[]> decompressor, int minimumSize) { }
+        public CompressionConfiguration(string compressionMethodName, System.Func<byte[], byte[]> compressor, int minimumSize, System.Func<byte[], byte[]> decompressor) { }
+        public CompressionConfiguration(string compressionMethodName, System.Func<byte[], byte[]> compressor, int minimumSize, System.Collections.Generic.Dictionary<string, System.Func<byte[], byte[]>> decompressors) { }
+        public void AddDecompressor(string compressionMethodName, System.Func<byte[], byte[]> decompressor) { }
     }
     public class static CompressionPluginExtensions
     {

--- a/src/ServiceBus.CompressionPlugin.Tests/When_compression_plugin_is_misconfigured.cs
+++ b/src/ServiceBus.CompressionPlugin.Tests/When_compression_plugin_is_misconfigured.cs
@@ -1,6 +1,7 @@
 ﻿namespace ServiceBus.CompressionPlugin.Tests
 {
     using System;
+    using System.Collections.Generic;
     using System.Threading.Tasks;
     using Microsoft.Azure.ServiceBus;
     using ServiceBus.CompressionPlugin;
@@ -11,7 +12,8 @@
         [Fact]
         public async Task Should_throw_meaningful_exception_for_erred_compression_func()
         {
-            var configuration = new CompressionConfiguration("test", bytes => throw new Exception("compressor threw"), bytes => null, 1);
+            var configuration = new CompressionConfiguration("test", bytes => throw new Exception("compressor threw"), 1,
+                new Dictionary<string, Func<byte[], byte[]>> { { "test", bytes => null } });
 
             var plugin = new CompressionPlugin(configuration);
 
@@ -25,7 +27,8 @@
         [Fact]
         public async Task Should_throw_meaningful_exception_for_erred_decompression_func()
         {
-            var configuration = new CompressionConfiguration("test", bytes => null, bytes => throw new Exception("decompressor threw"), 1);
+            var configuration = new CompressionConfiguration("test", bytes => null, 1,
+                new Dictionary<string, Func<byte[], byte[]>> { { "test", bytes => throw new Exception("decompressor threw") } });
 
             var plugin = new CompressionPlugin(configuration);
 
@@ -34,7 +37,23 @@
 
             var exception = await Assert.ThrowsAsync<Exception>(() => plugin.AfterMessageReceive(message));
 
-            Assert.StartsWith("User provided decompression delegate threw an exception.", exception.Message);
+            Assert.StartsWith($"User provided decompression delegate for '{configuration.CompressionMethodName}' compression method threw an exception.", exception.Message);
+        }
+
+        [Fact]
+        public async Task Should_throw_when_cannot_decompress_due_to_missing_decompressor_func()
+        {
+            var configuration = new CompressionConfiguration("test", bytes => null, 1,
+                new Dictionary<string, Func<byte[], byte[]>> { { "test", bytes => throw new Exception("decompressor threw") } });
+
+            var plugin = new CompressionPlugin(configuration);
+
+            var message = new Message(new byte[] { 1, 2, 3 });
+            message.UserProperties[Headers.CompressionMethodName] = "unknown-compression";
+
+            var exception = await Assert.ThrowsAsync<Exception>(() => plugin.AfterMessageReceive(message));
+
+            Assert.StartsWith($"{nameof(CompressionPlugin)} has not been configured to handle messages compressed using", exception.Message);
         }
     }
 }

--- a/src/ServiceBus.CompressionPlugin.Tests/When_receiving_message.cs
+++ b/src/ServiceBus.CompressionPlugin.Tests/When_receiving_message.cs
@@ -1,5 +1,10 @@
 ﻿namespace ServiceBus.CompressionPlugin.Tests
 {
+    using System;
+    using System.Collections.Generic;
+    using System.IO;
+    using System.IO.Compression;
+    using System.Linq;
     using System.Threading.Tasks;
     using Microsoft.Azure.ServiceBus;
     using ServiceBus.CompressionPlugin;
@@ -8,68 +13,107 @@
     public class When_receiving_message
     {
         [Fact]
-        public async Task Should_not_attempt_to_decompress_if_no_compression_header_is_found()
+        public async Task Should_skip_decompression_if_no_compression_header_is_found()
         {
-            var bytes = new byte[] { 1, 2, 3 };
+            var body = new byte[] { 1, 2, 3 };
+            var message = new Message(body);
+
+            var decompressorExecuted = false;
+
+            var receivePlugin = new CompressionPlugin(
+                new CompressionConfiguration("noop", bytes => bytes, 1,
+                    new Dictionary<string, Func<byte[], byte[]>>
+                    {
+                        {
+                            "compression-x", bytes =>
+                            {
+                                decompressorExecuted = true;
+                                return bytes;
+                            }
+                        }
+                    }));
+
+            var receivedMessage = await receivePlugin.AfterMessageReceive(message);
+
+            Assert.Equal(body, receivedMessage.Body);
+
+            Assert.False(decompressorExecuted, "Decompressing function should not have executed, but it did.");
+        }
+
+        [Fact]
+        public async Task Should_throw_for_not_configured_compression_method()
+        {
+            var bytes = new byte[] {1, 2, 3};
             var message = new Message(bytes);
 
             var plugin = new CompressionPlugin(new GzipCompressionConfiguration());
             var sentMessage = await plugin.BeforeMessageSend(message);
             sentMessage.UserProperties[Headers.CompressionMethodName] = "Unknown";
 
-            var receivedMessage = await plugin.AfterMessageReceive(sentMessage);
+            await Assert.ThrowsAsync<Exception>(() => plugin.AfterMessageReceive(sentMessage));
+        }
+
+        [Fact]
+        public async Task Should_be_able_to_decompress_messages_sent_with_different_compression_other_than_default()
+        {
+            var deflateCompressionConfiguration = new DeflateCompressionConfiguration();
+
+            var gzipCompressionConfiguration = new GzipCompressionConfiguration(1);
+            gzipCompressionConfiguration.AddDecompressor(deflateCompressionConfiguration.CompressionMethodName, DeflateDecompressor);
+
+            var bytes = Enumerable.Range(1, 1024).Select(x => (byte)x).ToArray();
+            var message = new Message(bytes);
+            message.UserProperties[Headers.CompressionMethodName] = deflateCompressionConfiguration.CompressionMethodName;
+
+            var sendPlugin = new CompressionPlugin(deflateCompressionConfiguration);
+            var sentMessage = await sendPlugin.BeforeMessageSend(message);
+
+            var receivePlugin = new CompressionPlugin(gzipCompressionConfiguration);
+            var receivedMessage = await receivePlugin.AfterMessageReceive(sentMessage);
 
             Assert.Equal(bytes, receivedMessage.Body);
         }
 
-        [Fact]
-        public async Task Should_not_attempt_to_decompress_if_compression_header_is_different_from_configured_method()
+        class DeflateCompressionConfiguration : CompressionConfiguration
         {
-            var message = new Message(new byte[] { 1, 2, 3 });
-            message.UserProperties[Headers.CompressionMethodName] = "GZip";
-
-            var sendPlugin = new CompressionPlugin(new GzipCompressionConfiguration());
-            var sentMessage = await sendPlugin.BeforeMessageSend(message);
-
-            var decompressorExecuted = false;
-
-            var receivePlugin = new CompressionPlugin(
-                new CompressionConfiguration(
-                    "noop",
-                    bytes => bytes,
-                    bytes =>
-                    {
-                        decompressorExecuted = true;
-                        return bytes;
-                    },
-                    1));
-
-            await receivePlugin.AfterMessageReceive(sentMessage);
-
-            Assert.False(decompressorExecuted, "Decompressing function should not have executed, but it did.");
+            public DeflateCompressionConfiguration() : base("Deflate", DeflateCompressor, 1, DeflateDecompressor) { }
         }
 
-        [Fact]
-        public async Task Should_skip_decompression_if_no_compression_header_is_found()
+        static byte[] DeflateCompressor(byte[] bytes)
         {
-            var message = new Message(new byte[] { 1, 2, 3 });
+            using (var compressStream = new MemoryStream())
+            using (var compressor = new DeflateStream(compressStream, CompressionMode.Compress))
+            {
+                compressor.Write(bytes, 0, bytes.Length);
+                compressor.Flush();
+                compressor.Close();
+                return compressStream.GetBuffer();
+            }
+        }
 
-            var decompressorExecuted = false;
-
-            var receivePlugin = new CompressionPlugin(
-                new CompressionConfiguration(
-                    "noop",
-                    bytes => bytes,
-                    bytes =>
+        static byte[] DeflateDecompressor(byte[] bytes)
+        {
+            using (var memoryStream = new MemoryStream(bytes))
+            using (var decompressStream = new DeflateStream(memoryStream, CompressionMode.Decompress))
+            {
+                const int size = 4096;
+                var buffer = new byte[size];
+                using (var memory = new MemoryStream())
+                {
+                    int count;
+                    do
                     {
-                        decompressorExecuted = true;
-                        return bytes;
-                    },
-                    1));
+                        count = decompressStream.Read(buffer, 0, size);
+                        if (count > 0)
+                        {
+                            memory.Write(buffer, 0, count);
+                        }
+                    }
+                    while (count > 0);
 
-            await receivePlugin.AfterMessageReceive(message);
-
-            Assert.False(decompressorExecuted, "Decompressing function should not have executed, but it did.");
+                    return memory.ToArray();
+                }
+            }
         }
     }
 }

--- a/src/ServiceBus.CompressionPlugin/CompressionConfiguration.cs
+++ b/src/ServiceBus.CompressionPlugin/CompressionConfiguration.cs
@@ -1,34 +1,53 @@
 ﻿namespace Microsoft.Azure.ServiceBus
 {
     using System;
+    using System.Collections.Generic;
+    using global::ServiceBus.CompressionPlugin;
 
     /// <summary>Runtime configuration for Compression plugin.</summary>
     public class CompressionConfiguration
     {
+        Dictionary<string, Func<byte[], byte[]>> mutableDecompressors;
+
+        /// <summary>
+        /// Compression configuration object to customize Compression plugin.
+        /// <remarks>Additional decompressors can be registered using AddDecompressor(name, function) API.</remarks>
+        ///  </summary>
+        /// <param name="compressionMethodName">Compression method name stored as a custom header.</param>
+        /// <param name="compressor">Function to compress an array of bytes.</param>
+        /// <param name="minimumSize">Minimum size of array for compression to be applied.</param>
+        /// <param name="decompressor">Single function to decompressor and array of bytes.</param>
+        public CompressionConfiguration(string compressionMethodName, Func<byte[], byte[]> compressor, int minimumSize, Func<byte[], byte[]> decompressor)
+            : this(compressionMethodName, compressor, minimumSize, new Dictionary<string, Func<byte[], byte[]>> { {compressionMethodName, decompressor} })
+        {
+        }
+
         /// <summary>
         /// Compression configuration object to customize Compression plugin.
         /// </summary>
         /// <param name="compressionMethodName">Compression method name stored as a custom header.</param>
         /// <param name="compressor">Function to compress an array of bytes.</param>
-        /// <param name="decompressor">Function to de-compress an array of bytes.</param>
         /// <param name="minimumSize">Minimum size of array for compression to be applied.</param>
-        public CompressionConfiguration(string compressionMethodName, Func<byte[], byte[]> compressor, Func<byte[], byte[]> decompressor, int minimumSize)
+        /// <param name="decompressors">Dictionary of function to de-compress an array of bytes where keys are compression names.</param>
+        public CompressionConfiguration(string compressionMethodName, Func<byte[], byte[]> compressor, int minimumSize, Dictionary<string, Func<byte[], byte[]>> decompressors)
         {
             Guard.AgainstEmpty(nameof(compressionMethodName), compressionMethodName);
             Guard.AgainstNull(nameof(compressor), compressor);
-            Guard.AgainstNull(nameof(decompressor), decompressor);
+            Guard.AgainstNull(nameof(decompressors), decompressors);
+            Guard.GuardAgainstEmptyCollection(nameof(decompressors), decompressors);
             Guard.AgainstNegativeOrZero(nameof(minimumSize), minimumSize);
 
-            this.CompressionMethodName = compressionMethodName;
-            this.MinimumSize = minimumSize;
-            this.Compressor = GetSafeCompressor(compressor);
-            this.Decompressor = GetSafeDecompressor(decompressor);
+            CompressionMethodName = compressionMethodName;
+            MinimumSize = minimumSize;
+            Compressor = GetSafeCompressor(compressor);
+            mutableDecompressors = decompressors;
+            Decompressors = GetSafeDecompressor(decompressors);
         }
 
         internal string CompressionMethodName { get; }
         internal int MinimumSize { get; }
         internal Func<byte[], byte[]> Compressor { get; }
-        internal Func<byte[], byte[]> Decompressor { get; }
+        internal Func<string, byte[], byte[]> Decompressors { get; }
 
         Func<byte[], byte[]> GetSafeCompressor(Func<byte[], byte[]> userProvidedCompressor)
         {
@@ -45,19 +64,34 @@
             };
         }
 
-        Func<byte[], byte[]> GetSafeDecompressor(Func<byte[], byte[]> userProvidedDecompressor)
+        Func<string, byte[], byte[]> GetSafeDecompressor(Dictionary<string, Func<byte[], byte[]>> userProvidedDecompressors)
         {
-            return bytes =>
+            return (compressionMethodName, bytes) =>
             {
+                if (!userProvidedDecompressors.TryGetValue(compressionMethodName, out var decompressor))
+                {
+                    throw new Exception($"{nameof(CompressionPlugin)} has not been configured to handle messages compressed using '{compressionMethodName}', but a message with this compression has been received. Re-configure plugin to handle '{compressionMethodName}' for decompression.");
+                }
+
                 try
                 {
-                    return userProvidedDecompressor(bytes);
+                    return decompressor(bytes);
                 }
                 catch (Exception e)
                 {
-                    throw new Exception("User provided decompression delegate threw an exception.", e);
+                    throw new Exception($"User provided decompression delegate for '{compressionMethodName}' compression method threw an exception.", e);
                 }
             };
+        }
+
+        /// <summary>
+        /// Add additional decompression method.
+        /// </summary>
+        /// <param name="compressionMethodName"></param>
+        /// <param name="decompressor"></param>
+        public void AddDecompressor(string compressionMethodName, Func<byte[], byte[]> decompressor)
+        {
+            mutableDecompressors.Add(compressionMethodName, decompressor);
         }
     }
 }

--- a/src/ServiceBus.CompressionPlugin/CompressionPlugin.cs
+++ b/src/ServiceBus.CompressionPlugin/CompressionPlugin.cs
@@ -49,12 +49,13 @@
                 return Task.FromResult(message);
             }
 
-            if (!message.UserProperties.TryGetValue(Headers.CompressionMethodName, out var methodName) || (string)methodName != configuration.CompressionMethodName)
+            if (!message.UserProperties.TryGetValue(Headers.CompressionMethodName, out var methodName))
             {
                 return Task.FromResult(message);
             }
 
-            message.Body = configuration.Decompressor(message.Body);
+            message.Body = configuration.Decompressors((string) methodName, message.Body);
+
             return Task.FromResult(message);
         }
     }

--- a/src/ServiceBus.CompressionPlugin/ExposeInternals.cs
+++ b/src/ServiceBus.CompressionPlugin/ExposeInternals.cs
@@ -1,3 +1,4 @@
-﻿using System.Runtime.CompilerServices;
+﻿
+using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("ServiceBus.CompressionPlugin.Tests")]

--- a/src/ServiceBus.CompressionPlugin/Guard.cs
+++ b/src/ServiceBus.CompressionPlugin/Guard.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections;
 
 static class Guard
 {
@@ -9,6 +10,7 @@ static class Guard
             throw new ArgumentNullException(argumentName);
         }
     }
+
     public static void AgainstNull(string argumentName, object value)
     {
         if (value == null)
@@ -22,6 +24,14 @@ static class Guard
         if (value <= 0)
         {
             throw new ArgumentException($"Value cannot be negative or zero. Value was: {value}.", argumentName);
+        }
+    }
+
+    public static void GuardAgainstEmptyCollection(string argumentName, ICollection collection)
+    {
+        if (collection != null && collection.Count == 0)
+        {
+            throw new ArgumentException("Collection should not be empty.", argumentName);
         }
     }
 }

--- a/src/ServiceBus.CompressionPlugin/GzipCompressionConfiguration.cs
+++ b/src/ServiceBus.CompressionPlugin/GzipCompressionConfiguration.cs
@@ -1,5 +1,7 @@
 ﻿namespace ServiceBus.CompressionPlugin
 {
+    using System;
+    using System.Collections.Generic;
     using System.IO;
     using System.IO.Compression;
     using Microsoft.Azure.ServiceBus;
@@ -9,7 +11,7 @@
         public const int MinimumCompressionSize = 1500;
 
         public GzipCompressionConfiguration(int minimumSizeToApplyCompression = MinimumCompressionSize)
-            : base("GZip", GzipCompressor, GzipDecompressor, minimumSizeToApplyCompression)
+            : base("GZip", GzipCompressor, minimumSizeToApplyCompression, new Dictionary<string, Func<byte[], byte[]>> { {"GZip", GzipDecompressor} })
         {
         }
 
@@ -28,7 +30,8 @@
 
         static byte[] GzipDecompressor(byte[] bytes)
         {
-            using (var gzipStream = new GZipStream(new MemoryStream(bytes), CompressionMode.Decompress))
+            using (var memoryStream = new MemoryStream(bytes))
+            using (var gzipStream = new GZipStream(memoryStream, CompressionMode.Decompress))
             {
                 const int size = 4096;
                 var buffer = new byte[size];


### PR DESCRIPTION
Fixes #9 and #11 
Removes the need in #12 

- Added API to [register multiple decompressors](https://github.com/SeanFeldman/ServiceBus.CompressionPlugin/blob/fe8ef85bb665cb2723cdb5f1fffa352dc6a27007/src/ServiceBus.CompressionPlugin/CompressionConfiguration.cs).
- Added API to add decompressors to an [already defined `CompressionConfiguration`](https://github.com/SeanFeldman/ServiceBus.CompressionPlugin/blob/fe8ef85bb665cb2723cdb5f1fffa352dc6a27007/src/ServiceBus.CompressionPlugin/CompressionConfiguration.cs#L92).

An example is in the test [`When_receiving_message.Should_be_able_to_decompress_messages_sent_with_different_compression_other_than_default`](https://github.com/SeanFeldman/ServiceBus.CompressionPlugin/blob/fe8ef85bb665cb2723cdb5f1fffa352dc6a27007/src/ServiceBus.CompressionPlugin.Tests/When_receiving_message.cs#L57)

```c#
// Sender
var deflateCompressionConfiguration = new DeflateCompressionConfiguration();

var sender = new MessageSender(connectionString, queueName);
sender.RegisterCompressionPlugin(deflateCompressionConfiguration);

var message = new Message(bytes);
await sender.SendAsync(message);

// Receiver
var gzipCompressionConfiguration = new GzipCompressionConfiguration();
gzipCompressionConfiguration.AddDecompressor("Deflate", DeflateDecompressor);

var receiver = new MessageReceiver(connectionString, entityPath, ReceiveMode.ReceiveAndDelete);
receiver.RegisterCompressionPlugin();
var receivedMessage = await receiver.ReceiveAsync().ConfigureAwait(false);
```